### PR TITLE
Info Button in Annotation Opens Apple-Maps Directions

### DIFF
--- a/Seattle Trails/ParkMapController.swift
+++ b/Seattle Trails/ParkMapController.swift
@@ -17,6 +17,10 @@ class ColoredAnnotation: MKPointAnnotation
 {
     var color: UIColor?
 }
+class DrivingButton: UIButton
+{
+    var coordinate: CLLocationCoordinate2D?
+}
 
 /**
 The ParkMapController is responsible for directly handling the parks, and translating them into map view pins and lines.
@@ -149,13 +153,19 @@ class ParkMapController: UIViewController, MKMapViewDelegate, CLLocationManagerD
 		{
 			return nil
 		}
-		
+        // Can we remove this and define the annotation methods here? -David W
 		self.annotationButtonClosure(view);
-		
+        
+        // Button Takes User To Maps Directions
+        let driving = DrivingButton(type: .DetailDisclosure)
+        driving.coordinate = annotation.coordinate
+        driving.addTarget(self, action: #selector(self.drivingButtonPressed(_:)), forControlEvents: UIControlEvents.TouchUpInside)
+        view.rightCalloutAccessoryView = driving
+        
 		view.canShowCallout = true
 		return view
 	}
-	
+    
 	func mapView(mapView: MKMapView, didSelectAnnotationView view: MKAnnotationView)
 	{
 		if let _ = view.annotation as? MKUserLocation
@@ -193,6 +203,16 @@ class ParkMapController: UIViewController, MKMapViewDelegate, CLLocationManagerD
 	}
 	
 	//MARK: helper methods
+    
+    func drivingButtonPressed(button: DrivingButton)
+    {
+        if let coords = button.coordinate {
+            let placemark = MKPlacemark(coordinate: coords, addressDictionary: nil)
+            let mapItem = MKMapItem(placemark: placemark)
+            let launchOptions = [MKLaunchOptionsDirectionsModeKey : MKLaunchOptionsDirectionsModeDriving]
+            mapItem.openInMapsWithLaunchOptions(launchOptions)
+        }
+    }
 	
 	/**
 	Given a park this will move the map view to it and draw all it's lines.

--- a/Seattle Trails/ViewController.swift
+++ b/Seattle Trails/ViewController.swift
@@ -283,25 +283,14 @@ class ViewController: ParkMapController, UITextFieldDelegate, UIPopoverPresentat
     func setupAnnotationButtonClosure()
     {
         //TODO: assign custom images to these buttons using setImage
-        
         self.annotationButtonClosure = { (view) in
-            let driving = UIButton(type: UIButtonType.DetailDisclosure)
-            //			driving.setImage(<#T##image: UIImage?##UIImage?#>, forState: .Normal)
-            driving.addTarget(self, action: #selector(self.drivingButtonPressed), forControlEvents: UIControlEvents.TouchUpInside)
-            view.rightCalloutAccessoryView = driving
-            
             let volunteering = UIButton(type: UIButtonType.ContactAdd)
             //			volunteering.setImage(<#T##image: UIImage?##UIImage?#>, forState: .Normal)
             volunteering.addTarget(self, action: #selector(self.volunteeringButtonPressed), forControlEvents: UIControlEvents.TouchUpInside)
             view.leftCalloutAccessoryView = volunteering
         }
     }
-    
-    func drivingButtonPressed()
-    {
-        //TODO: show driving directions
-    }
-    
+
     func volunteeringButtonPressed()
     {
         let mailView = self.mailerView.volunteerForParks()


### PR DESCRIPTION
Annotations have an info button that will open Apple Maps with directions.

I didn't follow the existing pattern.  Instead of coding within ViewController.setupAnnotationButtonClosure(), I decided it would be easier to define it in ParkMapController.mapView( viewForAnnotation ).  Custom button passes the coordinates through the button click.  Hope that's okay with everyone.

It shouldn't matter, because I think we may have concluded that the Volunteer button shouldn't be in the annotation anyway?
